### PR TITLE
Add Python settings management

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,17 @@ The project is configured for deployment on Vercel, but can be deployed on any p
 
 - `NEXT_PUBLIC_ANALYTICS_ID`: Vercel Analytics ID (optional)
 
+Python tooling is available to manage additional secrets:
+
+```bash
+python generate_secrets_example.py
+```
+
+This creates a `secrets_example.env` file with placeholders for required values
+defined in `config.py` (`DB_URL`, `API_KEY`, `DEBUG_MODE`). Copy this file to
+`.env` and edit the values or export them in your environment before running any
+Python code that calls `config.get_settings()`.
+
 ## 🤝 Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.

--- a/config.py
+++ b/config.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pydantic import BaseSettings, Field, PostgresDsn, constr
+
+
+class Settings(BaseSettings):
+    """Application configuration loaded from environment variables."""
+
+    DB_URL: PostgresDsn = Field(
+        ...,
+        description="Database connection string",
+        example="postgresql://user:pass@localhost/dbname",
+    )
+    API_KEY: constr(min_length=32) = Field(
+        ..., description="API authentication key", example="your_api_key_here"
+    )
+    DEBUG_MODE: bool = Field(
+        False, description="Enable debug output", example=False
+    )
+
+    class Config:
+        env_file = ".env"
+        case_sensitive = True
+
+
+_settings: Settings | None = None
+
+
+def get_settings() -> Settings:
+    """Return the validated application settings."""
+    global _settings
+    if _settings is None:
+        _settings = Settings()
+    return _settings

--- a/generate_secrets_example.py
+++ b/generate_secrets_example.py
@@ -1,0 +1,26 @@
+"""Generate a placeholder secrets_example.env from the Settings model."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from config import Settings
+
+
+def generate(file_path: str | Path = "secrets_example.env") -> None:
+    fields = Settings.__fields__
+    lines = ["# Example secrets file"]
+    for name, field in sorted(fields.items()):
+        env_name = field.alias
+        example = field.field_info.extra.get("example")
+        if example is None:
+            if field.default is not None:
+                example = str(field.default)
+            else:
+                example = ""
+        lines.append(f"{env_name}={example}")
+
+    Path(file_path).write_text("\n".join(lines) + "\n")
+
+
+if __name__ == "__main__":
+    generate()

--- a/secrets_example.env
+++ b/secrets_example.env
@@ -1,0 +1,4 @@
+# Example secrets file
+API_KEY=your_api_key_here
+DB_URL=postgresql://user:pass@localhost/dbname
+DEBUG_MODE=False


### PR DESCRIPTION
## Summary
- provide `config.py` with pydantic `Settings`
- auto-generate `secrets_example.env` with `generate_secrets_example.py`
- document Python secret management in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445911c264832dba5381b166b4504f